### PR TITLE
Do not queue sprites/meshes if there are no views

### DIFF
--- a/pipelined/bevy_pbr2/src/render/mod.rs
+++ b/pipelined/bevy_pbr2/src/render/mod.rs
@@ -487,6 +487,10 @@ pub fn queue_meshes(
 ) {
     let mesh_meta = mesh_meta.into_inner();
 
+    if view_meta.uniforms.len() == 0 {
+        return;
+    }
+
     light_meta.shadow_view_bind_group.get_or_insert_with(|| {
         render_device.create_bind_group(&BindGroupDescriptor {
             entries: &[BindGroupEntry {

--- a/pipelined/bevy_render2/src/render_resource/uniform_vec.rs
+++ b/pipelined/bevy_render2/src/render_resource/uniform_vec.rs
@@ -45,6 +45,11 @@ impl<T: AsStd140> UniformVec<T> {
     }
 
     #[inline]
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    #[inline]
     pub fn capacity(&self) -> usize {
         self.capacity
     }
@@ -143,6 +148,11 @@ impl<T: AsStd140> DynamicUniformVec<T> {
     #[inline]
     pub fn binding(&self) -> BindingResource {
         self.uniform_vec.binding()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.uniform_vec.len()
     }
 
     #[inline]

--- a/pipelined/bevy_render2/src/renderer/render_device.rs
+++ b/pipelined/bevy_render2/src/renderer/render_device.rs
@@ -36,7 +36,10 @@ impl RenderDevice {
 
     /// Creates a shader module from either SPIR-V or WGSL source code.
     #[inline]
-    pub fn create_shader_module<'a>(&self, desc: impl Into<wgpu::ShaderModuleDescriptor<'a>>) -> wgpu::ShaderModule {
+    pub fn create_shader_module<'a>(
+        &self,
+        desc: impl Into<wgpu::ShaderModuleDescriptor<'a>>,
+    ) -> wgpu::ShaderModule {
         self.device.create_shader_module(&desc.into())
     }
 

--- a/pipelined/bevy_sprite2/src/render/mod.rs
+++ b/pipelined/bevy_sprite2/src/render/mod.rs
@@ -287,6 +287,10 @@ pub fn queue_sprites(
     gpu_images: Res<RenderAssets<Image>>,
     mut views: Query<&mut RenderPhase<Transparent2dPhase>>,
 ) {
+    if view_meta.uniforms.len() == 0 {
+        return;
+    }
+
     // TODO: define this without needing to check every frame
     sprite_meta.view_bind_group.get_or_insert_with(|| {
         render_device.create_bind_group(&BindGroupDescriptor {

--- a/pipelined/bevy_sprite2/src/render/mod.rs
+++ b/pipelined/bevy_sprite2/src/render/mod.rs
@@ -2,7 +2,18 @@ use crate::Sprite;
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::{prelude::*, system::SystemState};
 use bevy_math::{Mat4, Vec2, Vec3, Vec4Swizzles};
-use bevy_render2::{core_pipeline::Transparent2dPhase, mesh::{shape::Quad, Indices, Mesh, VertexAttributeValues}, render_asset::RenderAssets, render_graph::{Node, NodeRunError, RenderGraphContext}, render_phase::{Draw, DrawFunctions, Drawable, RenderPhase, TrackedRenderPass}, render_resource::*, renderer::{RenderContext, RenderDevice}, shader::Shader, texture::{BevyDefault, Image}, view::{ViewMeta, ViewUniform, ViewUniformOffset}};
+use bevy_render2::{
+    core_pipeline::Transparent2dPhase,
+    mesh::{shape::Quad, Indices, Mesh, VertexAttributeValues},
+    render_asset::RenderAssets,
+    render_graph::{Node, NodeRunError, RenderGraphContext},
+    render_phase::{Draw, DrawFunctions, Drawable, RenderPhase, TrackedRenderPass},
+    render_resource::*,
+    renderer::{RenderContext, RenderDevice},
+    shader::Shader,
+    texture::{BevyDefault, Image},
+    view::{ViewMeta, ViewUniform, ViewUniformOffset},
+};
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::slab::{FrameSlabMap, FrameSlabMapKey};
 use bytemuck::{Pod, Zeroable};


### PR DESCRIPTION
In my minkraft project I generate a bunch of blocky voxel chunks before spawning the character and camera to ensure there is ground for them to stand on. Unconditionally calling `view_meta.uniforms.binding()` assumes there are views and therefore there is a uniform buffer to use in the binding. So without this check, if there are not yet cameras in the scene, this call panics.