### PR TITLE
Small Fixes

### DIFF
--- a/pipelined/bevy_render2/src/render_phase/draw_state.rs
+++ b/pipelined/bevy_render2/src/render_phase/draw_state.rs
@@ -182,6 +182,14 @@ impl<'a> TrackedRenderPass<'a> {
             .set_index_buffer(buffer_slice.id(), offset, index_format);
     }
 
+    pub fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {
+        debug!(
+            "draw: {:?} {:?}",
+            vertices, instances
+        );
+        self.pass.draw(vertices, instances);
+    }
+
     pub fn draw_indexed(&mut self, indices: Range<u32>, base_vertex: i32, instances: Range<u32>) {
         debug!(
             "draw indexed: {:?} {} {:?}",

--- a/pipelined/bevy_render2/src/render_resource/buffer_vec.rs
+++ b/pipelined/bevy_render2/src/render_resource/buffer_vec.rs
@@ -85,7 +85,8 @@ impl<T: Pod> BufferVec<T> {
 
     pub fn write_to_staging_buffer(&self, render_device: &RenderDevice) {
         if let Some(staging_buffer) = &self.staging_buffer {
-            let slice = staging_buffer.slice(..);
+            let end = (self.values.len() * self.item_size) as u64;
+            let slice = staging_buffer.slice(0..end);
             render_device.map_buffer(&slice, wgpu::MapMode::Write);
             {
                 let mut data = slice.get_mapped_range_mut();


### PR DESCRIPTION
This PR does makes a few small changes:
 * Added missing `TrackedRenderPass::draw`.
 * Writing out to the staging buffer in `BufferVec` with a size smaller than the staging buffer panics. Fixed this panic by only copying the data that is available.