### PR TITLE
Fixed issue with how texture arrays were uploaded with write_texture.

### DIFF
--- a/pipelined/bevy_render2/src/texture/image.rs
+++ b/pipelined/bevy_render2/src/texture/image.rs
@@ -375,7 +375,11 @@ impl RenderAsset for Image {
                     )
                     .unwrap(),
                 ),
-                rows_per_image: None,
+                rows_per_image: if image.texture_descriptor.size.depth_or_array_layers > 1 {
+                    std::num::NonZeroU32::new(image.texture_descriptor.size.height)
+                } else {
+                    None
+                },
             },
             image.texture_descriptor.size,
         );


### PR DESCRIPTION
This PR fixes a small issue where `reinterpret_stacked_2d_as_array` failed to upload using `queue.write_texture`. 