### PR TITLE
expose render subgraphs as iterator

### DIFF
--- a/pipelined/bevy_render2/src/render_graph/graph.rs
+++ b/pipelined/bevy_render2/src/render_graph/graph.rs
@@ -261,6 +261,18 @@ impl RenderGraph {
         self.nodes.values_mut()
     }
 
+    pub fn iter_sub_graphs(&self) -> impl Iterator<Item = (&str, &RenderGraph)> {
+        self.sub_graphs
+            .iter()
+            .map(|(name, graph)| (name.as_ref(), graph))
+    }
+
+    pub fn iter_sub_graphs_mut(&mut self) -> impl Iterator<Item = (&str, &mut RenderGraph)> {
+        self.sub_graphs
+            .iter_mut()
+            .map(|(name, graph)| (name.as_ref(), graph))
+    }
+
     pub fn iter_node_inputs(
         &self,
         label: impl Into<NodeLabel>,


### PR DESCRIPTION
This is in order to display the full rendergraph in [bevy_mod_debugdump](https://github.com/jakobhellermann/bevy_mod_debugdump/tree/pipelined):
<img src="https://raw.githubusercontent.com/jakobhellermann/bevy_mod_debugdump/pipelined/docs/render_graph.svg">