### PR TITLE
Suggested changes on bevy asset v2

### DIFF
--- a/crates/bevy_asset/examples/loader.rs
+++ b/crates/bevy_asset/examples/loader.rs
@@ -1,7 +1,7 @@
 use bevy_app::{App, Plugin, ScheduleRunnerPlugin, Startup, Update};
 use bevy_asset::{
     io::{Reader, Writer},
-    processor::{AssetProcessor, LoadAndSave},
+    processor::{AssetProcessor, LoadAndSave, ProcessContext},
     saver::{AssetSaver, SavedAsset},
     Asset, AssetApp, AssetLoader, AssetPlugin, AssetServer, Assets, Handle, LoadContext,
 };
@@ -153,6 +153,7 @@ impl AssetSaver for CoolTextSaver {
         writer: &'a mut Writer,
         asset: SavedAsset<'a, Self::Asset>,
         settings: &'a Self::Settings,
+        ctx: &'a mut ProcessContext,
     ) -> bevy_utils::BoxedFuture<'a, Result<TextSettings, anyhow::Error>> {
         Box::pin(async move {
             let text = format!("{}{}", asset.text.clone(), settings.appended);

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -92,12 +92,12 @@ pub struct InternalAssetHandle {
 
 impl Drop for InternalAssetHandle {
     fn drop(&mut self) {
-        if let Err(err) = self.drop_sender.send(DropEvent {
+        // ignore send errors because this means the channel is shut down / the game has
+        // stopped
+        let _ = self.drop_sender.send(DropEvent {
             id: self.id.internal(),
             asset_server_managed: self.asset_server_managed,
-        }) {
-            println!("Failed to send DropEvent for InternalAssetHandle {:?}", err);
-        }
+        });
     }
 }
 

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -32,6 +32,8 @@ pub use loader::*;
 pub use path::*;
 pub use reflect::*;
 pub use server::*;
+pub use anyhow::Error;
+pub use bevy_utils::BoxedFuture;
 
 use crate::{
     io::{processor_gated::ProcessorGatedReader, AssetProvider, AssetProviders},

--- a/crates/bevy_render/src/texture/compressed_image_saver.rs
+++ b/crates/bevy_render/src/texture/compressed_image_saver.rs
@@ -15,6 +15,7 @@ impl AssetSaver for CompressedImageSaver {
         writer: &'a mut bevy_asset::io::Writer,
         image: &'a Self::Asset,
         _settings: &'a Self::Settings,
+        ctx: &'a mut ProcessContext,
     ) -> bevy_utils::BoxedFuture<'a, std::result::Result<ImageLoaderSettings, anyhow::Error>> {
         // PERF: this should live inside the future, but CompressorParams and Compressor are not Send / can't be owned by the BoxedFuture (which _is_ Send)
         let mut compressor_params = basis_universal::CompressorParams::new();


### PR DESCRIPTION
This PR tries to do a few things on top of https://github.com/bevyengine/bevy/pull/8624:
- Pass `ProcessContext` to the `save` method on the `AssetSaver` trait.
- Re-export `anyhow::Error` and `bevy_utils::BoxedFuture` like we did before.
- Silence the print messages on Handle drop after app shutdown
- Add a `load_direct` to `ProcessContext` so that the processor may read other files during processing. In my case I was trying to run a GLSL to SPIR-V compiler, and I had to read the included files from the asset system. Please take a closer look at this method, as I'm not entirely sure that I'm handling the asset dependencies correctly.
 