### PR TITLE
Add expression support for `#`-name shorthand

### DIFF
--- a/crates/bevy_scene2/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene2/macros/src/bsn/codegen.rs
@@ -116,6 +116,15 @@ impl<const ALLOW_FLAT: bool> Bsn<ALLOW_FLAT> {
                             )
                         }
                     }
+                    BsnEntry::NameExpression(expr_tokens) => {
+                        quote! {
+                            <#bevy_ecs::name::Name as PatchGetTemplate>::patch(
+                                move |value| {
+                                    *value = Name({#expr_tokens}.into());
+                                }
+                            )
+                        }
+                    }
        
             });
         }

--- a/crates/bevy_scene2/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene2/macros/src/bsn/parse.rs
@@ -73,7 +73,11 @@ impl Parse for BsnEntry {
             BsnEntry::InheritedScene(input.parse::<BsnInheritedScene>()?)
         } else if input.peek(Token![#]) {
             input.parse::<Token![#]>()?;
-            BsnEntry::Name(input.parse::<Ident>()?)
+            if input.peek(Brace) {
+                BsnEntry::NameExpression(braced_tokens(input)?)
+            } else {
+                BsnEntry::Name(input.parse::<Ident>()?)
+            }
         } else if input.peek(Brace) {
             BsnEntry::SceneExpression(braced_tokens(input)?)
         } else if input.peek(Bracket) {

--- a/crates/bevy_scene2/macros/src/bsn/types.rs
+++ b/crates/bevy_scene2/macros/src/bsn/types.rs
@@ -12,6 +12,7 @@ pub struct Bsn<const ALLOW_FLAT: bool> {
 #[derive(Debug)]
 pub enum BsnEntry {
     Name(Ident),
+    NameExpression(TokenStream),
     GetTemplatePatch(BsnType),
     TemplatePatch(BsnType),
     GetTemplateConstructor(BsnConstructor),


### PR DESCRIPTION
https://github.com/bevyengine/bevy/pull/20158

The `#`-syntax currently allows specifying names using `Ident`s, which is nice.

This PR extends it to also support arbitrary expressions enclosed in braces:
```rust
let n = 5;
bsn! {
     #{format!("Tab_{n}")} Node
}
```