### PR TITLE
Don't assume entity still exists for `ScenePatch` `AssetEvent`

### DIFF
--- a/crates/bevy_scene2/src/spawn.rs
+++ b/crates/bevy_scene2/src/spawn.rs
@@ -96,8 +96,9 @@ pub fn spawn_queued(
                         };
 
                         for entity in entities {
-                            let mut entity_mut = world.get_entity_mut(entity).unwrap();
-                            scene.spawn(&mut entity_mut).unwrap();
+                            if let Ok(mut entity_mut) = world.get_entity_mut(entity) {
+                                scene.spawn(&mut entity_mut).unwrap();
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Prevent a panic when a `ScenePatchInstance` entity gets despawned before it's `ScenePatch` is loaded