### PR TITLE
Restore `bevy_feathers` features after merge with upstream

### DIFF
--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -100,8 +100,7 @@ pub fn tool_button(props: ButtonProps) -> impl Scene {
         template_value(props.variant)
         template_value(props.corners.to_border_radius(3.0))
         Hovered
-        // TODO: port CursonIcon to GetTemplate
-        // CursorIcon::System(bevy_window::SystemCursorIcon::Pointer)
+        EntityCursor::System(bevy_window::SystemCursorIcon::Pointer)
         TabIndex(0)
         ThemeBackgroundColor(tokens::BUTTON_BG)
         ThemeFontColor(tokens::BUTTON_TEXT)

--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -21,7 +21,6 @@ use crate::{
     tokens,
 };
 use bevy_input_focus::tab_navigation::TabIndex;
-use bevy_winit::cursor::CursorIcon;
 
 /// Color variants for buttons. This also functions as a component used by the dynamic styling
 /// system to identify which entities are buttons.

--- a/crates/bevy_feathers/src/controls/color_swatch.rs
+++ b/crates/bevy_feathers/src/controls/color_swatch.rs
@@ -1,15 +1,9 @@
-use bevy_asset::Handle;
 use bevy_color::Alpha;
 use bevy_ecs::component::Component;
-use bevy_ui::{BackgroundColor, BorderRadius, Node, PositionType, Val};
-use bevy_ui_render::ui_material::MaterialNode;
-
-use crate::{
-    alpha_pattern::{AlphaPattern, AlphaPatternMaterial},
-    constants::size,
-    palette,
-};
 use bevy_scene2::{bsn, Scene};
+use bevy_ui::{BackgroundColor, BorderRadius, Node, PositionType, Val};
+
+use crate::{alpha_pattern::AlphaPattern, constants::size, palette};
 
 /// Marker identifying a color swatch.
 #[derive(Component, Default, Clone)]
@@ -33,7 +27,6 @@ pub fn color_swatch() -> impl Scene {
         }
         ColorSwatch
         AlphaPattern
-        MaterialNode::<AlphaPatternMaterial>(Handle::default())
         BorderRadius::all(Val::Px(5.0))
         [
             Node {

--- a/crates/bevy_feathers/src/controls/mod.rs
+++ b/crates/bevy_feathers/src/controls/mod.rs
@@ -15,15 +15,12 @@ pub use radio::{radio, RadioPlugin};
 pub use slider::{slider, SliderPlugin, SliderProps};
 pub use toggle_switch::{toggle_switch, ToggleSwitchPlugin, ToggleSwitchProps};
 
-use crate::alpha_pattern::AlphaPatternPlugin;
-
 /// Plugin which registers all `bevy_feathers` controls.
 pub struct ControlsPlugin;
 
 impl Plugin for ControlsPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_plugins((
-            AlphaPatternPlugin,
             ButtonPlugin,
             CheckboxPlugin,
             RadioPlugin,

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -1,7 +1,7 @@
 use accesskit::Role;
 use bevy_a11y::AccessibilityNode;
 use bevy_app::{Plugin, PreUpdate};
-use bevy_core_widgets::{Callback, CallbackTemplate, CoreCheckbox, ValueChange};
+use bevy_core_widgets::{CallbackTemplate, CoreCheckbox, ValueChange};
 use bevy_ecs::{
     component::Component,
     entity::Entity,

--- a/crates/bevy_feathers/src/cursor.rs
+++ b/crates/bevy_feathers/src/cursor.rs
@@ -9,7 +9,6 @@ use bevy_ecs::{
     resource::Resource,
     schedule::IntoScheduleConfigs,
     system::{Commands, Query, Res},
-    template::GetTemplate,
     VariantDefaults,
 };
 use bevy_picking::{hover::HoverMap, pointer::PointerId, PickingSystems};

--- a/crates/bevy_feathers/src/lib.rs
+++ b/crates/bevy_feathers/src/lib.rs
@@ -25,7 +25,7 @@ use bevy_text::{TextColor, TextFont};
 use bevy_ui_render::UiMaterialPlugin;
 
 use crate::{
-    alpha_pattern::{AlphaPatternMaterial, AlphaPatternResource},
+    alpha_pattern::AlphaPatternMaterial,
     controls::ControlsPlugin,
     cursor::{CursorIconPlugin, DefaultCursor, EntityCursor},
     theme::{ThemedText, UiTheme},
@@ -78,7 +78,5 @@ impl Plugin for FeathersPlugin {
             .add_observer(theme::on_changed_border)
             .add_observer(theme::on_changed_font_color)
             .add_observer(font_styles::on_changed_font);
-
-        app.init_resource::<AlphaPatternResource>();
     }
 }

--- a/examples/ui/feathers.rs
+++ b/examples/ui/feathers.rs
@@ -12,7 +12,7 @@ use bevy::{
             subpane_header,
         },
         controls::{
-            button, checkbox, color_swatch, radio, slider, toggle_switch, ButtonProps,
+            button, checkbox, color_swatch, radio, slider, toggle_switch, tool_button, ButtonProps,
             ButtonVariant, CheckboxProps, SliderProps, ToggleSwitchProps,
         },
         dark_theme::create_dark_theme,
@@ -222,6 +222,82 @@ fn demo_root() -> impl Scene {
                     SliderPrecision(2)
                 ),
                 color_swatch(),
+            ],
+            Node {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::Stretch,
+                justify_content: JustifyContent::Start,
+                padding: UiRect::all(Val::Px(8.0)),
+                row_gap: Val::Px(8.0),
+                width: Val::Percent(30.),
+                min_width: Val::Px(200.),
+            } [
+                (
+                    :subpane [
+                        :subpane_header [
+                            (Text("Left") ThemedText),
+                            (Text("Center") ThemedText),
+                            (Text("Right") ThemedText)
+                        ],
+                        :subpane_body [
+                            (Text("Body") ThemedText),
+                        ],
+                    ]
+                ),
+                (
+                    :pane [
+                        :pane_header [
+                            :tool_button(ButtonProps {
+                                variant: ButtonVariant::Selected,
+                                ..default()
+                            }) [
+                                (Text("\u{0398}") ThemedText)
+                            ],
+                            :pane_header_divider,
+                            :tool_button(ButtonProps{
+                                variant: ButtonVariant::Plain,
+                                ..default()
+                            }) [
+                                (Text("\u{00BC}") ThemedText)
+                            ],
+                            :tool_button(ButtonProps{
+                                variant: ButtonVariant::Plain,
+                                ..default()
+                            }) [
+                                (Text("\u{00BD}") ThemedText)
+                            ],
+                            :tool_button(ButtonProps{
+                                variant: ButtonVariant::Plain,
+                                ..default()
+                            }) [
+                                (Text("\u{00BE}") ThemedText)
+                            ],
+                            :pane_header_divider,
+                            :tool_button(ButtonProps{
+                                variant: ButtonVariant::Plain,
+                                ..default()
+                            }) [
+                                (Text("\u{20AC}") ThemedText)
+                            ],
+                            :flex_spacer,
+                            :tool_button(ButtonProps{
+                                variant: ButtonVariant::Plain,
+                                ..default()
+                            }) [
+                                (Text("\u{00D7}") ThemedText)
+                            ],
+                        ],
+                        (
+                            :pane_body [
+                                (Text("Some") ThemedText),
+                                (Text("Content") ThemedText),
+                                (Text("Here") ThemedText),
+                            ]
+                            BackgroundColor(palettes::tailwind::EMERALD_800)
+                        ),
+                    ]
+                )
             ]
         ]
     }


### PR DESCRIPTION
https://github.com/bevyengine/bevy/pull/20158

Looks like the recent sync with bevy main caused us to lose some feathers stuff

- Added the (`next-gen-scenes`-specific) pane examples back to the feathers example
- Migrated tool_button to use `EntityCursor`
- Fixed `AlphaPattern` not setting the `MaterialNode` handle properly
  - This was probably due to the fact that `spawn_scene` does not insert the whole bundle at once yet
  - Now uses `#[require]` and a component hook to initialize it in a way that works with `spawn_scene` - a nice plus was this allowed us to get rid of the extra plugin and resource
- Cleaned up some unused imports

Back in business:
<img width="805" height="477" alt="Screenshot 2025-08-02 at 19 24 13" src="https://github.com/user-attachments/assets/96fa9497-eb4f-4387-8968-21b255584c31" />
