### PR TITLE
Fix `scene_spawn` within template

### DIFF
--- a/crates/bevy_scene2/src/lib.rs
+++ b/crates/bevy_scene2/src/lib.rs
@@ -32,8 +32,10 @@ pub struct ScenePlugin;
 impl Plugin for ScenePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<QueuedScenes>()
+            .init_resource::<NewScenes>()
             .init_asset::<ScenePatch>()
-            .add_systems(Update, (resolve_scene_patches, spawn_queued).chain());
+            .add_systems(Update, (resolve_scene_patches, spawn_queued).chain())
+            .add_observer(on_add_scene_patch_instance);
     }
 }
 

--- a/crates/bevy_scene2/src/spawn.rs
+++ b/crates/bevy_scene2/src/spawn.rs
@@ -62,39 +62,51 @@ pub struct QueuedScenes {
     waiting_entities: HashMap<AssetId<ScenePatch>, Vec<Entity>>,
 }
 
+#[derive(Resource, Default)]
+pub struct NewScenes {
+    entities: Vec<Entity>,
+}
+
+pub fn on_add_scene_patch_instance(
+    trigger: On<Add, ScenePatchInstance>,
+    mut new_scenes: ResMut<NewScenes>,
+) {
+    new_scenes.entities.push(trigger.target());
+}
+
 pub fn spawn_queued(
     world: &mut World,
-    handles: &mut QueryState<(Entity, &ScenePatchInstance), Added<ScenePatchInstance>>,
+    handles: &mut QueryState<&ScenePatchInstance>,
     mut reader: Local<EventCursor<AssetEvent<ScenePatch>>>,
 ) {
     world.resource_scope(|world, mut patches: Mut<Assets<ScenePatch>>| {
         world.resource_scope(|world, mut queued: Mut<QueuedScenes>| {
             world.resource_scope(|world, events: Mut<Events<AssetEvent<ScenePatch>>>| {
-                for (entity, id) in handles
-                    .iter(world)
-                    .map(|(e, h)| (e, h.id()))
-                    .collect::<Vec<_>>()
-                {
-                    if let Some(scene) = patches.get_mut(id).and_then(|p| p.resolved.as_mut()) {
-                        let mut entity_mut = world.get_entity_mut(entity).unwrap();
-                        scene.spawn(&mut entity_mut).unwrap();
-                    } else {
-                        let entities = queued.waiting_entities.entry(id).or_default();
-                        entities.push(entity);
+                loop {
+                    let mut new_scenes = world.resource_mut::<NewScenes>();
+                    if new_scenes.entities.is_empty() {
+                        break;
+                    }
+                    for entity in core::mem::take(&mut new_scenes.entities) {
+                        if let Ok(id) = handles.get(world, entity).map(|h| h.id()) {
+                            if let Some(scene) =
+                                patches.get_mut(id).and_then(|p| p.resolved.as_mut())
+                            {
+                                let mut entity_mut = world.get_entity_mut(entity).unwrap();
+                                scene.spawn(&mut entity_mut).unwrap();
+                            } else {
+                                let entities = queued.waiting_entities.entry(id).or_default();
+                                entities.push(entity);
+                            }
+                        }
                     }
                 }
 
                 for event in reader.read(&events) {
-                    if let AssetEvent::LoadedWithDependencies { id } = event {
-                        let Some(scene) = patches.get_mut(*id).and_then(|p| p.resolved.as_mut())
-                        else {
-                            continue;
-                        };
-
-                        let Some(entities) = queued.waiting_entities.remove(id) else {
-                            continue;
-                        };
-
+                    if let AssetEvent::LoadedWithDependencies { id } = event
+                        && let Some(scene) = patches.get_mut(*id).and_then(|p| p.resolved.as_mut())
+                        && let Some(entities) = queued.waiting_entities.remove(id)
+                    {
                         for entity in entities {
                             if let Ok(mut entity_mut) = world.get_entity_mut(entity) {
                                 scene.spawn(&mut entity_mut).unwrap();


### PR DESCRIPTION
Calling `spawn_scene` from a template like this does not spawn the scene.
```rust
commands.spawn_scene(bsn!(template(|entity| {
    entity.world_scope(|world| {
        world.spawn_scene(bsn! (...));
    });
    Ok(())
})));
```
The call to `world.spawn_scene` ends up happening within `spawn_queued` and therefore the inserted `ScenePatchInstance` component never matches the `Added<ScenePatchInstance>` filter of the system, and so the scene is never spawned.

Instead of the `Added` filter, this PR adds the `NewScenes` resource to store newly queued scene spawns. It is populated via an `On<Add, ScenePatchInstance>` observer.
Then, within `spawn_queued` we also loop until no more new scenes are produced by the calls to `scene.spawn` to avoid delaying 'nested' scene spawns until the next frame, or even later

And I could not resist changing the event reading portion to use let chains :)