### PR TITLE
Mark `Trigger::trigger` as `unsafe`

### DIFF
--- a/crates/bevy_animation/src/animation_event.rs
+++ b/crates/bevy_animation/src/animation_event.rs
@@ -20,8 +20,13 @@ pub struct AnimationEventTrigger {
     pub animation_player: Entity,
 }
 
-impl<E: AnimationEvent> Trigger<E> for AnimationEventTrigger {
-    fn trigger(
+#[expect(
+    unsafe_code,
+    reason = "We must implement this trait to define a custom Trigger, which is required to be unsafe due to safety considerations within bevy_ecs."
+)]
+unsafe impl<E: AnimationEvent> Trigger<E> for AnimationEventTrigger {
+    /// SAFETY: TODO!
+    unsafe fn trigger(
         &mut self,
         world: DeferredWorld,
         observers: &CachedObservers,

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![forbid(unsafe_code)]
+#![warn(unsafe_code)]
 #![doc(
     html_logo_url = "https://bevy.org/assets/icon.png",
     html_favicon_url = "https://bevy.org/assets/icon.png"

--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -28,8 +28,26 @@ pub unsafe trait Trigger<E: Event> {
     /// [`Trigger`] and the state stored on `self`.
     ///
     /// SAFETY: TODO!
+    // To understand why this must be unsafe, we must think carefully about the lifetimes involved.
+    //
+    // The core challenge is that the lifetime of the `&mut E::Trigger<'_>` that we want to create
+    // within our `observer_system_runner` may not be the same as the lifetime provided by Event::Trigger<'a>.
+    //
+    // If the lifetimes are the same, then we can safely create a `&mut E::Trigger<'_>` from the `PtrMut`
+    // passed to the observer runner function, and pass that to the observer system inside of 'On'.
+    //
+    // If the lifetimes are not the same, then we must be careful to ensure that the `&mut E::Trigger<'_>` we create
+    // does not outlive the `PtrMut` that was passed to the observer runner function.
+    // Failing to do so could lead to use-after-free bugs.
+    //
+    // To avoid this, we require that the caller of this function (i.e. the code that triggers the event)
+    // ensures that TODO.
+    //
+    // This is complex, and ways to simplify this would be welcome in the future!
     // The safety requirements of this method were prompted by this comment thread:
     // https://github.com/bevyengine/bevy/pull/20731#discussion_r2311907935
+    //
+    // which also discusses some alternative designs that were considered.
     unsafe fn trigger(
         &mut self,
         world: DeferredWorld,

--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -21,10 +21,16 @@ use core::marker::PhantomData;
 /// - [`EntityTrigger`]: The [`EntityEvent`] derive defaults to using this
 /// - [`PropagateEntityTrigger`]: The [`EntityEvent`] derive uses this when propagation is enabled.
 /// - [`EntityComponentsTrigger`]: Used by Bevy's [component lifecycle events](crate::lifecycle).
-pub trait Trigger<E: Event> {
+///
+/// SAFETY: TODO!
+pub unsafe trait Trigger<E: Event> {
     /// Trigger the given `event`, running every [`Observer`](crate::observer::Observer) that matches the `event`, as defined by this
     /// [`Trigger`] and the state stored on `self`.
-    fn trigger(
+    ///
+    /// SAFETY: TODO!
+    // The safety requirements of this method were prompted by this comment thread:
+    // https://github.com/bevyengine/bevy/pull/20731#discussion_r2311907935
+    unsafe fn trigger(
         &mut self,
         world: DeferredWorld,
         observers: &CachedObservers,
@@ -40,8 +46,9 @@ pub trait Trigger<E: Event> {
 #[derive(Default)]
 pub struct GlobalTrigger;
 
-impl<E: Event> Trigger<E> for GlobalTrigger {
-    fn trigger(
+unsafe impl<E: Event> Trigger<E> for GlobalTrigger {
+    /// SAFETY: TODO!
+    unsafe fn trigger(
         &mut self,
         world: DeferredWorld,
         observers: &CachedObservers,
@@ -87,8 +94,9 @@ impl GlobalTrigger {
 #[derive(Default)]
 pub struct EntityTrigger;
 
-impl<E: EntityEvent> Trigger<E> for EntityTrigger {
-    fn trigger(
+unsafe impl<E: EntityEvent> Trigger<E> for EntityTrigger {
+    /// SAFETY: TODO!
+    unsafe fn trigger(
         &mut self,
         world: DeferredWorld,
         observers: &CachedObservers,
@@ -177,10 +185,11 @@ impl<const AUTO_PROPAGATE: bool, E: EntityEvent, T: Traversal<E>> Default
     }
 }
 
-impl<const AUTO_PROPAGATE: bool, E: EntityEvent, T: Traversal<E>> Trigger<E>
+unsafe impl<const AUTO_PROPAGATE: bool, E: EntityEvent, T: Traversal<E>> Trigger<E>
     for PropagateEntityTrigger<AUTO_PROPAGATE, E, T>
 {
-    fn trigger(
+    /// SAFETY: TODO!
+    unsafe fn trigger(
         &mut self,
         mut world: DeferredWorld,
         observers: &CachedObservers,
@@ -237,8 +246,9 @@ pub struct EntityComponentsTrigger<'a> {
     pub components: &'a [ComponentId],
 }
 
-impl<'a, E: EntityEvent> Trigger<E> for EntityComponentsTrigger<'a> {
-    fn trigger(
+unsafe impl<'a, E: EntityEvent> Trigger<E> for EntityComponentsTrigger<'a> {
+    /// SAFETY: TODO!
+    unsafe fn trigger(
         &mut self,
         world: DeferredWorld,
         observers: &CachedObservers,

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -47,7 +47,7 @@ pub(super) fn observer_system_runner<E: Event, B: Bundle, S: ObserverSystem<E, B
     let trigger: &mut E::Trigger<'_> = unsafe { trigger_ptr.deref_mut() };
 
     let on: On<E, B> = On::new(
-        // SAFETY: Caller ensures `ptr` is castable to `&mut T`
+        // SAFETY: Caller ensures `ptr` is castable to `&mut E`
         unsafe { event_ptr.deref_mut() },
         observer,
         trigger,

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -42,6 +42,8 @@ pub(super) fn observer_system_runner<E: Event, B: Bundle, S: ObserverSystem<E, B
     state.last_trigger_id = last_trigger;
 
     // SAFETY: Caller ensures `trigger_ptr` is castable to `&mut E::Trigger<'_>`
+    // This is enforced by the safety requirements of `Trigger::trigger`
+    // See the safety discussion on `Trigger::trigger` for more details.
     let trigger: &mut E::Trigger<'_> = unsafe { trigger_ptr.deref_mut() };
 
     let on: On<E, B> = On::new(

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -18,9 +18,11 @@ use bevy_ptr::PtrMut;
 /// Typically refers to the default runner that runs the system stored in the associated [`Observer`] component,
 /// but can be overridden for custom behavior.
 pub type ObserverRunner =
-    fn(DeferredWorld, observer: Entity, &TriggerContext, event: PtrMut, trigger: PtrMut);
+    unsafe fn(DeferredWorld, observer: Entity, &TriggerContext, event: PtrMut, trigger: PtrMut);
 
-pub(super) fn observer_system_runner<E: Event, B: Bundle, S: ObserverSystem<E, B>>(
+// SAFETY: TODO!
+// See the safety discussion on `Trigger::trigger` for more details.
+pub(super) unsafe fn observer_system_runner<E: Event, B: Bundle, S: ObserverSystem<E, B>>(
     mut world: DeferredWorld,
     observer: Entity,
     trigger_context: &TriggerContext,

--- a/crates/bevy_ecs/src/observer/system_param.rs
+++ b/crates/bevy_ecs/src/observer/system_param.rs
@@ -28,6 +28,8 @@ use core::{
 /// Providing multiple components in this bundle will cause this event to be triggered by any
 /// matching component in the bundle,
 /// [rather than requiring all of them to be present](https://github.com/bevyengine/bevy/issues/15325).
+// SAFETY: this type must never expose anything with the 'w lifetime other than `E::trigger<'w>`
+// See the safety discussion on `Trigger::trigger` for more details.
 pub struct On<'w, 't, E: Event, B: Bundle = ()> {
     observer: Entity,
     event: &'w mut E,

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -787,7 +787,9 @@ impl<'w> DeferredWorld<'w> {
     /// Triggers all `event` observers for the given `targets`
     ///
     /// # Safety
+    ///
     /// Caller must ensure `E` is accessible as the type represented by `event_key`
+    /// TODO: capture safety requirements of `E::Trigger::trigger`
     #[inline]
     pub unsafe fn trigger_raw<'a, E: Event>(
         &mut self,
@@ -807,7 +809,11 @@ impl<'w> DeferredWorld<'w> {
             (world.into_deferred(), observers)
         };
         let context = TriggerContext { event_key, caller };
-        trigger.trigger(world.reborrow(), observers, &context, event);
+
+        // SAFETY: TODO!
+        unsafe {
+            trigger.trigger(world.reborrow(), observers, &context, event);
+        }
     }
 
     /// Sends a global [`Event`] without any targets.


### PR DESCRIPTION
I am attempting to implement the suggestions discussed in https://github.com/bevyengine/bevy/pull/20731#discussion_r2311907935, courtesy of @SkiFire13 and @chescock.


# TODO

- [ ] write all of the safety comments arising from marking `Trigger::trigger` and `observer_system_runner` as `unsafe`
- [ ] implement one of the suggestions outlined in https://github.com/bevyengine/bevy/pull/20731#discussion_r2328703267, probably by-value triggers
