### PR TITLE
Allow scenes to use Entity's directly

### DIFF
--- a/crates/bevy_ecs/src/entity/entity_path.rs
+++ b/crates/bevy_ecs/src/entity/entity_path.rs
@@ -3,6 +3,48 @@ use log::warn;
 use std::{borrow::Cow, string::String};
 use thiserror::Error;
 
+/// Either a path to an entity, or an entity.
+pub enum EntityOrPath<'a> {
+    /// An entity
+    Entity(Entity),
+    /// A path to an entity
+    Path(EntityPath<'a>),
+}
+
+impl<'a> Default for EntityOrPath<'a> {
+    fn default() -> Self {
+        Self::Path(Default::default())
+    }
+}
+
+impl<'a> From<Entity> for EntityOrPath<'a> {
+    #[inline]
+    fn from(entity: Entity) -> Self {
+        Self::Entity(entity)
+    }
+}
+
+impl<'a> From<&'a str> for EntityOrPath<'a> {
+    #[inline]
+    fn from(entity_path: &'a str) -> Self {
+        Self::Path(EntityPath::from(entity_path))
+    }
+}
+
+impl<'a> From<&'a String> for EntityOrPath<'a> {
+    #[inline]
+    fn from(entity_path: &'a String) -> Self {
+        Self::Path(EntityPath::from(entity_path))
+    }
+}
+
+impl From<String> for EntityOrPath<'static> {
+    #[inline]
+    fn from(asset_path: String) -> Self {
+        Self::Path(EntityPath::from(asset_path))
+    }
+}
+
 /// A path to an entity.
 pub struct EntityPath<'a>(Cow<'a, str>);
 

--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -4,7 +4,7 @@ pub use bevy_ecs_macros::GetTemplate;
 
 use crate::{
     bundle::Bundle,
-    entity::{Entity, EntityPath},
+    entity::{Entity, EntityOrPath},
     error::{BevyError, Result},
     world::EntityWorldMut,
 };
@@ -70,16 +70,19 @@ pub struct TemplateTuple<T>(pub T);
 
 all_tuples!(template_impl, 0, 12, T);
 
-impl Template for EntityPath<'static> {
+impl Template for EntityOrPath<'static> {
     type Output = Entity;
 
     fn build(&mut self, entity: &mut EntityWorldMut) -> Result<Self::Output> {
-        Ok(entity.resolve_path(self)?)
+        match self {
+            Self::Entity(entity) => Ok(*entity),
+            Self::Path(path) => Ok(entity.resolve_path(path)?),
+        }
     }
 }
 
 impl GetTemplate for Entity {
-    type Template = EntityPath<'static>;
+    type Template = EntityOrPath<'static>;
 }
 
 impl<T: Clone + Default> Template for T {


### PR DESCRIPTION
Previously when trying to reference entities in scenes was basically impossible due to the template implementation using `EntityPath`.

- Added `EntityOrPath` containing either `Entity` or `EntityPath`
- Changed `Entity`'s template to use `EntityOrPath`

