### PR TITLE
Fix doctest and make it more practical.

### DIFF
--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -119,18 +119,22 @@ pub trait Reader: AsyncRead + Unpin + Send + Sync {
     /// when it fails, such as reading into a seek-able [`Vec`] (or [`AsyncSeek`]-able [`VecReader`]):
     ///
     /// ```
-    /// # use bevy_asset::io::{VecReader, Reader, AsyncSeekExt};
+    /// # use bevy_asset::{io::{VecReader, Reader}, AsyncSeekExt};
     /// # use std::{io::SeekFrom, vec::Vec};
-    /// # let mut vec_reader = VecReader::new(Vec::new());
-    /// # let reader: &mut dyn Reader = &mut vec_reader;
+    /// # async {
+    /// # let mut original_reader = VecReader::new(Vec::new());
+    /// # let reader: &mut dyn Reader = &mut original_reader;
+    /// let mut fallback_reader;
     /// let reader = match reader.seekable() {
     ///     Ok(seek) => seek,
     ///     Err(_) => {
-    ///         reader.read_to_end(&mut data.bytes).await.unwrap();
-    ///         &mut data
+    ///         fallback_reader = VecReader::new(Vec::new());
+    ///         reader.read_to_end(&mut fallback_reader.bytes).await.unwrap();
+    ///         &mut fallback_reader
     ///     }
     /// };
     /// reader.seek(SeekFrom::Start(10)).await.unwrap();
+    /// # };
     /// ```
     fn seekable(&mut self) -> Result<&mut dyn SeekableReader, ReaderNotSeekableError>;
 }


### PR DESCRIPTION
Doc test did not compile, and now we have an example of deferring the fallback reader, but still being able to use either!